### PR TITLE
Use bash rather than sh

### DIFF
--- a/wrye-bash-install.sh
+++ b/wrye-bash-install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ## This script installs the python version of Wrye Bash to the Wine prefix of your choice
 # it then gives you a choice of how you wanna run Wrye Bash, CLI or .desktop file


### PR DESCRIPTION
Update shebang line to always use bash, even on systems where sh is
not a symlink to that shell.

At least some of the syntax in wrye-install relies on non-POSIX shell
extensions in bash.  On some Linux systems, sh is symlinked to
/bin/bash.  On others, it is not.  On current Debian-family Linux
systems, it is symlinked to /bin/dash, which does not understand the
"[[" bash extension, which was causing wrye-install to fail with
syntax errors on such systems.